### PR TITLE
Mbarba/tweaks

### DIFF
--- a/config/gene_model_logFile.conf
+++ b/config/gene_model_logFile.conf
@@ -7,7 +7,7 @@ log4perl.appender.TOSCREEN.stderr = 0;
 log4perl.appender.TOSCREEN.layout = Log::Log4perl::Layout::SimpleLayout
 
 log4perl.appender.LOGFILE=Log::Log4perl::Appender::File
-log4perl.appender.LOGFILE.filename=
+log4perl.appender.LOGFILE.filename=./gene_diff_info.log
 log4perl.appender.LOGFILE.mode=append
 
 log4perl.appender.LOGFILE.layout=PatternLayout
@@ -15,7 +15,7 @@ log4perl.appender.LOGFILE.layout.ConversionPattern=[%r] %F %L %c - %m%n
 
 
 log4perl.appender.INFOFILE=Log::Log4perl::Appender::File
-log4perl.appender.INFOFILE.filename=
+log4perl.appender.INFOFILE.filename=./gene_diff_debug.log
 log4perl.appender.INFOFILE.mode=append
 
 log4perl.appender.INFOFILE.layout=PatternLayout

--- a/modules/Initialize.pm
+++ b/modules/Initialize.pm
@@ -85,6 +85,11 @@ sub load_gene_set {
 	my $pre_loaded = _gff_load($gff_file,$fasta_file,$dsn,$user,$pass);
 	
 	my @genes = $db->get_features_by_type('gene');
+	my @prot_genes = $db->get_features_by_type('protein_coding_gene');
+  
+  print(scalar(@genes) . " biotype 'gene'\n");
+  print(scalar(@prot_genes) . " biotype 'protein_coding_gene'\n");
+  @genes = (@genes, @prot_genes);
     open my $validation_fh,'>>',$validation_file;
 	foreach my $gene (@genes){
 		

--- a/script/run_gene_model_diff.pl
+++ b/script/run_gene_model_diff.pl
@@ -102,6 +102,11 @@ my $datadir= $config->val('Data','datadir');
 my $scriptdir = $FindBin::Bin;
 my $species_list = get_species($options{speciesFile});
 my $log_file = $config->val('Data','log_file');
+
+if (not ($log_file)) {
+  $log_file = "$FindBin::Bin/../config/gene_model_logFile.conf";
+  print STDERR "Using default log config from $log_file\n";
+}
 Log::Log4perl->init($log_file);
 
 foreach my $species (@{$species_list}){

--- a/script/run_gene_model_diff.pl
+++ b/script/run_gene_model_diff.pl
@@ -91,7 +91,10 @@ my $dbh;
 my %options;
 my $result = GetOptions(\%options,
 		'config|f=s',
-		'speciesFile=s') || pod2usage(2);
+		'speciesFile=s') or pod2usage(2);
+
+if (not $options{config}) { print "Missing --config\n"; pod2usage(2); }
+if (not $options{speciesFile}) { print "Missing --speciesFile\n"; pod3usage(2); }
 #------------------------------------------------#
 
 my $config = readConfig($options{config});


### PR DESCRIPTION
Simpler logging, + import protein_coding_genes

- Load genes with biotype "protein_coding_gene" if the core.gff use them
- use a default logging file, so no need to provide one in the config file (unless you want the log files to be created differently)