### PR TITLE
Mbarba/partial fix

### DIFF
--- a/modules/Validate.pm
+++ b/modules/Validate.pm
@@ -93,6 +93,7 @@ sub validate_gene {
 	$gene_hash{strand}   = $gene->strand;
 	$gene_hash{start}    = $gene->start;
 	$gene_hash{end}      = $gene->end;
+	my $strand = $gene->strand;
 	
 	my @RNAs = $gene->get_SeqFeatures('mRNA');
 	my $gene_validation_status = 0;
@@ -105,26 +106,38 @@ sub validate_gene {
 		
 		my $NO_ATG = 0;
 		my $NO_STOP = 0;
+
+		my $has_no_atg = exists $mRNA_attb{'no-ATG'};
+		my $has_no_stop = exists $mRNA_attb{'no-STOP'};
+		my $has_author = (exists $mRNA_attb{owner} and $validation_approved_email{ $mRNA_attb{owner}->[0] });
+		my $is_left_partial = (exists $mRNA_attb{'is_fmin_partial'} and ($mRNA_attb{'is_fmin_partial'}->[0] eq 'true'));
+		my $is_right_partial = (exists $mRNA_attb{'is_fmax_partial'} and ($mRNA_attb{'is_fmax_partial'}->[0] eq 'true'));
+		my $is_start_partial = (($strand == 1 and $is_left_partial) or ($strand == '-1' and $is_right_partial));
+		my $is_end_partial = (($strand == 1 and $is_right_partial) or ($strand == '-1' and $is_left_partial));
     
     # Check both missing start/stop codon
     # and allow if partial, or owner approved
-		if (exists $mRNA_attb{'no-ATG'}) {
-			if (exists $validation_approved_email{$mRNA_attb{owner}->[0]}
-          or exists $mRNA_attb{'is_fmin_partial'}) {
+		if ($has_no_atg) {
+			if ($has_author) {
 				$NO_ATG = 2;
 			} else {
         $NO_ATG = 1;
       }
 		}
+    if ($is_start_partial) {
+      $NO_ATG = 2;
+    }
 		
-		if (exists $mRNA_attb{'no-STOP'}) {
-			if (exists $validation_approved_email{$mRNA_attb{owner}->[0]}
-          or exists $mRNA_attb{'is_fmax_partial'}) {
+		if ($has_no_stop) {
+			if ($has_author or $is_end_partial) {
 				$NO_STOP = 2;
 			} else {
         $NO_STOP = 1;
       }
 		}
+    if ($is_end_partial) {
+      $NO_STOP = 2;
+    }
 				
 		eval {
 				my $mRNA_ID   = $mRNA_attb{load_id}->[0];

--- a/script/run_gene_model_diff.pl
+++ b/script/run_gene_model_diff.pl
@@ -367,6 +367,7 @@ sub write_gff_to_load {
 		chomp $line;
 		
 		my @columns = split/\t/, $line;
+    next if @columns == 0;
     if (scalar(@columns) != 9) {
       warn("Not 9 columns in the gff: $line\n");
     }

--- a/script/run_gene_model_diff.pl
+++ b/script/run_gene_model_diff.pl
@@ -212,6 +212,9 @@ sub prune_gff_by_scaffold {
 		next if not $scaffold;
 		$cap_scaffold{$scaffold} = 1;
 	}
+  
+	my %known_cap_scaffold = %cap_scaffold;
+  my $n_total = scalar(keys %known_cap_scaffold);
 	
 	while (my $line = <$core_fh>) {		
 		next if $line =~ /^###/;
@@ -222,9 +225,17 @@ sub prune_gff_by_scaffold {
       next if not $scaffold;
 			if (exists $cap_scaffold{$scaffold}) {
 				print $pruned_core_gff_fh $line;
+        delete $known_cap_scaffold{$scaffold};
 			}
 		}
 	}
+  
+  # Check that all scaffolds have been found
+  if (%known_cap_scaffold) {
+    my $n_left = scalar(keys %known_cap_scaffold);
+    die("$n_left/$n_total scaffolds from the cap.gff have not been found in the core.gff");
+  }
+  
 	return $pruned_core_gff;	
 }
 

--- a/script/run_gene_model_diff.pl
+++ b/script/run_gene_model_diff.pl
@@ -186,10 +186,11 @@ sub load_data_base {
 	
 	my $pruned_core_gff = prune_gff_by_scaffold($cap_gff,$core_gff);
 	
-	my ($cap_pre_loaded, $cap_obsolete, $cap_not_finished, $cap_not_validated, $cap_total_loaded) = Initialize::load_gene_set($dbh, $config, $validation_file_cap, 'cap', $cap_gff, $cap_fasta, $dns, $user, $pass);
-	warn "Stats: loaded=$cap_pre_loaded, obsolete=$cap_obsolete, not_finished=$cap_not_finished, not_validated=$cap_not_validated, total_loaded=$cap_total_loaded\n";
+	my ($cap_pre_loaded, $cap_obsolete, $cap_not_finished, $cap_not_validated, $cap_no_gene_model, $cap_total_loaded) = Initialize::load_gene_set($dbh, $config, $validation_file_cap, 'cap', $cap_gff, $cap_fasta, $dns, $user, $pass);
+	warn "CAP Stats: loaded=$cap_pre_loaded, obsolete=$cap_obsolete, not_finished=$cap_not_finished, not_validated=$cap_not_validated, no_gene_model=$cap_no_gene_model, total_loaded=$cap_total_loaded\n";
 	if($cap_total_loaded){
-		my ($vb_pre_loaded, $vb_obsolete, $vb_not_finished, $vb_not_validated, $vb_total_loaded) = Initialize::load_gene_set($dbh, $config, $validation_file_core, 'vb', $pruned_core_gff, $core_fasta, $dns, $user, $pass);
+		my ($vb_pre_loaded, $vb_obsolete, $vb_not_finished, $vb_not_validated, $vb_no_gene_model, $vb_total_loaded) = Initialize::load_gene_set($dbh, $config, $validation_file_core, 'vb', $pruned_core_gff, $core_fasta, $dns, $user, $pass);
+	warn "VB Stats: loaded=$vb_pre_loaded, obsolete=$vb_obsolete, not_finished=$vb_not_finished, not_validated=$vb_not_validated, no_gene_model=$vb_no_gene_model, total_loaded=$vb_total_loaded\n";
 	}
 	return $cap_total_loaded;
  	


### PR DESCRIPTION
Correct the way fmin_partial and max_partial are handled: it must take the strand into consideration to get the corresponding 5'/3'.
Also take selenocysteine into account, as long as they are in the form Note="stop_codon_redefined_as_selenocysteine".