### PR TITLE
Add artifacts skip

### DIFF
--- a/modules/GeneModel.pm
+++ b/modules/GeneModel.pm
@@ -97,6 +97,9 @@ my %known_biotypes = (
     repeat_region
     five_prime_UTR
     three_prime_UTR
+    deletion_artifact
+    insertion_artifact
+    substitution_artifact
   )]
 );
 


### PR DESCRIPTION
These fixes are not used, but they are indirectly included in the protein fasta sequences