### PR TITLE
CDS_error mapping = broken_gene

### DIFF
--- a/modules/AnnotationEvents.pm
+++ b/modules/AnnotationEvents.pm
@@ -146,6 +146,41 @@ sub get_changed_genes {
   return $gene_count;
 }
 
+=head2 
+
+ Title: get_broken_genes   	
+ Usage: AnnotationEvents::get_broken_genes($dbh)   	
+ Function: Gets CDS_error from the gene_mapping table and inserts them as broken_gene in to the gene_events table  	
+ Returns: Count of broken genes 
+ Args: Database handle object	     
+=cut
+
+sub get_broken_genes {
+  my ($dbh) = @_;
+
+  my $gene_count              = 0;
+  my $insert_sth = $dbh->prepare(get_sql('gene_events'));
+
+  my @maptypes = qw(CDS_error);
+  my @changed_genes;
+
+  foreach my $maptype (@maptypes) {
+    push @changed_genes, @{GeneMapping::get_gene_mappings_by_maptype($dbh, $maptype);};
+  }
+
+  foreach my $row (@changed_genes) {
+    my $cap_gene_id = $row->[0];
+    my $vb_gene_id  = $row->[1];
+    my $cap_biotype = $row->[2];
+    my $vb_biotype = $row->[3];
+    my $event_name = "broken_gene";
+    $insert_sth->execute($vb_gene_id, $cap_gene_id, $event_name, $vb_biotype, $cap_biotype);
+    $gene_count++;
+  }
+
+  return $gene_count;
+}
+
 =head2
  Title: get_lost_iso_form   	
  Usage: AnnotationEvents::get_lost_iso_form($dbh)   	

--- a/script/run_gene_model_diff.pl
+++ b/script/run_gene_model_diff.pl
@@ -70,6 +70,7 @@ use GeneModel qw(%BIOTYPE);
 
 my $event_new_count;
 my $event_change_count;
+my $event_broken_count;
 my $event_iso_gain_count;
 my $event_iso_lost_count;
 my $event_merge_count;
@@ -81,6 +82,7 @@ my $gff_gene_count;
 my $identical_gene_count;
 my $new_gene_count;
 my $changed_gene_count;
+my $broken_gene_count;
 my $iso_lost_gene_count;
 my $iso_gain_gene_count;
 my @merged_gene_counts;
@@ -119,6 +121,7 @@ sub run_species {
 
   $event_new_count      = 0;
   $event_change_count   = 0;
+  $event_broken_count   = 0;
   $event_iso_gain_count = 0;
   $event_iso_lost_count = 0;
   $event_merge_count    = 0;
@@ -289,6 +292,7 @@ sub get_events {
   $identical_gene_count = AnnotationEvents::get_identical_gene($dbh);
   $new_gene_count       = AnnotationEvents::get_new_gene($dbh);
   $changed_gene_count   = AnnotationEvents::get_changed_genes($dbh);
+  $broken_gene_count   = AnnotationEvents::get_broken_genes($dbh);
   $iso_gain_gene_count  = AnnotationEvents::get_gain_iso_form($dbh);
   $iso_lost_gene_count  = AnnotationEvents::get_lost_iso_form($dbh);
   @merged_gene_counts   = AnnotationEvents::get_merge($dbh);
@@ -321,6 +325,7 @@ sub write_events {
     new_gene      => "+",
     merge_gene    => ">",
     split_gene    => "<",
+    broken_gene   => "=!",
   );
 
   foreach my $row (@{$events_ref}) {
@@ -350,6 +355,8 @@ sub write_events {
 
     if ($event eq 'change_gene') {
       $event_change_count++;
+    } elsif ($event eq 'broken_gene') {
+      $event_broken_count++;
     } elsif ($event eq 'gain_iso_form') {
       $event_iso_gain_count++;
     } elsif ($event eq 'lost_iso_form') {
@@ -491,6 +498,7 @@ sub write_summary_counts {
 "Merge gene events:\t$event_merge_count ($merged_gene_counts[0],$merged_gene_counts[1],$merged_gene_counts[2])\n";
   print $file_fh
 "Split gene events:\t$event_split_count ($split_gene_counts[0],$split_gene_counts[1],$split_gene_counts[2])\n";
+  print $file_fh "Broken gene events:\t$event_broken_count ($broken_gene_count)\n";
   print $file_fh "Total genes deleted:\t$delete_total_count\n";
   print $file_fh "Total genes loaded:\t$load_total_count\n";
   print $file_fh "GFF gene count:\t$gff_gene_count\n";


### PR DESCRIPTION
If we accept CDS with "errors" (like with selenocysteines), without protein sequence, then we get gene mappings map_type=CDS_error

Those are not shown in the summary+events file.

So: add a "broken_gene" type, with symbol "!=".